### PR TITLE
Fixed 'Associate' input amount formula.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ General association action (e.g. "change password") to attach content to a walle
 - PySPOOL: ```pyspool.Association(FEDERATION, address, hash, reason=<string>)```
 - Bitcoin:
 ```
-TX = [(FEDERATION : FEE+DUST] 
+TX = [(FEDERATION : FEE+2*DUST] 
      -> 
      [(hash : DUST), 
       (address : DUST), 


### PR DESCRIPTION
The cost to associate a content to a wallet is two times DUST (one to 'hash', the other to 'address') plus FEE.
